### PR TITLE
Fix error in podspec

### DIFF
--- a/ios/RNReadWriteExif.podspec
+++ b/ios/RNReadWriteExif.podspec
@@ -4,9 +4,9 @@ Pod::Spec.new do |s|
   s.version      = "1.0.0"
   s.summary      = "RNReadWriteExif"
   s.description  = <<-DESC
-                  RNReadWriteExif
+                  Provide utilities to read photo EXIF metadatas in React Native
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/floristic-project/react-native-read-write-exif"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Issue: 
```
[!] The `RNBackwardPlantnet` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```

Linked to https://github.com/floristic-project/react-native-backward-plantnet/pull/1